### PR TITLE
Add Engineering Leaders Community (ELC) to Communities

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@
 - [LeadDev Community](https://leaddev.com/) - Articles, talks, and events for engineering leaders.
 - [Engineering Managers Slack](https://engmanagers.github.io/) - Slack community focused on EM challenges.
 - [CTO Craft](https://ctocraft.com/) - Community and events for CTOs and engineering leaders.
+- [Engineering Leaders Community (ELC)](https://www.engineeringleaders.io/) - 2,000+ engineering leaders across Central Europe. Monthly in-person meetups in Prague and an annual conference.
 - [Hacker News](https://news.ycombinator.com/) - Not EM-specific, but essential reading for staying connected to what engineers care about.
 
 <p align="right">(<a href="#contents">back to top</a>)</p>


### PR DESCRIPTION
Adds the Central European engineering leaders community to the Communities section: 2,000+ members, monthly in-person meetups in Prague, annual conference. Fills the region gap next to the US/UK-centric entries.

Disclosure: I run this community, so the numbers are first-hand and the bias is declared.