### PR TITLE
Add Engineering Leaders Conference to Conferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@
 - [QCon](https://qconferences.com/) - Software development conferences with management tracks.
 - [CTO Craft Con](https://conference.ctocraft.com/) - Conference focused on engineering leadership.
 - [DevOpsDays](https://devopsdays.org/) - Community-organized conferences worldwide with strong leadership content.
+- [Engineering Leaders Conference](https://www.elc-conference.io/) - Annual conference for engineering leaders in Prague. 500+ attendees, speakers from companies like Netflix and Stripe.
 - [StaffPlus](https://leaddev.com/staffplus) - By LeadDev, focused on staff+ engineers and technical leaders.
 
 <p align="right">(<a href="#contents">back to top</a>)</p>


### PR DESCRIPTION
Adds the annual Prague conference for engineering leaders: 500+ attendees, speakers from companies like Netflix and Stripe. Complements LeadDev Berlin as the CEE option.

Disclosure: I organize it. Separate PR per entry so each stands on its own merits.